### PR TITLE
Allow installing on other platforms

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,4 @@
   "devDependencies": {
     "electron-rebuild": "^1.7.3"
   },
-  "os": [
-    "win32"
-  ]
 }


### PR DESCRIPTION
Since the `sources` in `binding.gyp` are empty by default, we'll be able to complete an `npm i` on non-Windows platforms.